### PR TITLE
Fix crash on Chromium browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
   <body>
     <div id="score"></div>
     <div id="you"></div>
-    <a id="link" href="http://a/%%30%30">LINK OF DEATH<br> http://a/%%30%30</a>
+    <a id="link" href="https://en.wikipedia.org/wiki/Death">LINK OF DEATH<br>https://en.wikipedia.org/wiki/Death</a>
     <a href="https://github.com/DVLP/LinkOfDeath"><img style="position: absolute; top: 0; left: 0; border: 0;" src="https://camo.githubusercontent.com/82b228a3648bf44fc1163ef44c62fcc60081495e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_red_aa0000.png"></a>
   </body>
 </html>


### PR DESCRIPTION
Currently Chrome and other Chromium apps crash when hovering over links with %%30%30 in them: [crbug.com/533361](https://code.google.com/p/chromium/issues/detail?id=533361)

This provides a workaround by replacing the bad url with a more innocuous one. This can be reverted once most Chrome installations in the wild have been patched.

References: szhu/3030#1
